### PR TITLE
webapp: shorten long numbers (fixes #266)

### DIFF
--- a/repology-webapp/src/template_funcs.rs
+++ b/repology-webapp/src/template_funcs.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 Dmitry Marakasov <amdmi3@amdmi3.ru>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use askama::filters::Safe;
 use url::Url;
 
 /// Given an url, try to extract domain for Qualys SSL Server Test
@@ -13,6 +14,41 @@ pub fn extract_domain_for_ssltest(url: &str) -> Option<String> {
         url.domain().map(|domain| domain.into())
     } else {
         None
+    }
+}
+
+/// Format a number into a short string representation
+///
+/// If the number is greater than or equal to 1,000, it will be
+/// represented in thousands with a "k" suffix (e.g. 1,200 → "1k").
+/// Otherwise, it will be returned as a plain string.
+pub fn format_number_short(number: &i32) -> Safe<String> {
+    if *number >= 1_000 {
+        let short_value = *number as f32 / 1_000.0;
+        Safe(format!(
+            r#"<span title="{}">{}k</span>"#,
+            *number,
+            format_significant(short_value, 3)
+        ))
+    } else {
+        Safe((*number).to_string())
+    }
+}
+
+fn format_significant(value: f32, sigfigs: usize) -> String {
+    if value == 0.0 {
+        return "0".into();
+    }
+    let order = value.abs().log10().floor() as i32;
+    let decimals = (sigfigs as i32 - order - 1).max(0) as usize;
+    let formatted = format!("{:.*}", decimals, value);
+    if formatted.contains('.') {
+        formatted
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    } else {
+        formatted
     }
 }
 
@@ -66,5 +102,32 @@ mod tests {
             assert_eq!(extract_domain_for_ssltest("example.com"), None);
             assert_eq!(extract_domain_for_ssltest("file:///example.com"), None);
         }
+    }
+
+    #[test]
+    fn test_format_number_short() {
+        assert_eq!(
+            super::format_number_short(&12345).0,
+            "<span title=\"12345\">12.3k</span>".to_owned()
+        );
+        assert_eq!(
+            super::format_number_short(&2345).0,
+            "<span title=\"2345\">2.35k</span>".to_owned()
+        );
+        assert_eq!(
+            super::format_number_short(&1500).0,
+            "<span title=\"1500\">1.5k</span>".to_owned()
+        );
+        assert_eq!(
+            super::format_number_short(&1001).0,
+            "<span title=\"1001\">1k</span>".to_owned()
+        );
+        assert_eq!(super::format_number_short(&999).0, "999".to_owned());
+        assert_eq!(
+            super::format_number_short(&1000).0,
+            "<span title=\"1000\">1k</span>".to_owned()
+        );
+        assert_eq!(super::format_number_short(&171).0, "171".to_owned());
+        assert_eq!(super::format_number_short(&0).0, "0".to_owned());
     }
 }

--- a/repology-webapp/templates/repositories/packages.html
+++ b/repology-webapp/templates/repositories/packages.html
@@ -50,21 +50,21 @@
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Repository, [("repository_name", repository.name.as_str())])? }}">{{ repository.title }}</a>
 			</th>
 
-			<td class="text-center">{{ repository.num_packages }}</td>
+			<td class="text-center">{{- crate::template_funcs::format_number_short(repository.num_packages) -}}</td>
 
-			<td class="text-center version-cell version-big version-newest">{{ repository.num_packages_newest }}</td>
-			<td class="text-center version-cell version-big version-devel">{{ repository.num_packages_devel }}</td>
-			<td class="text-center version-cell version-big version-unique">{{ repository.num_packages_unique }}</td>
-			<td class="text-center version-cell version-big version-outdated">{{ repository.num_packages_outdated }}</td>
-			<td class="text-center version-cell version-big version-legacy">{{ repository.num_packages_legacy }}</td>
+			<td class="text-center version-cell version-big version-newest">{{- crate::template_funcs::format_number_short(repository.num_packages_newest) -}}</td>
+			<td class="text-center version-cell version-big version-devel">{{- crate::template_funcs::format_number_short(repository.num_packages_devel) -}}</td>
+			<td class="text-center version-cell version-big version-unique">{{- crate::template_funcs::format_number_short(repository.num_packages_unique) -}}</td>
+			<td class="text-center version-cell version-big version-outdated">{{- crate::template_funcs::format_number_short(repository.num_packages_outdated) -}}</td>
+			<td class="text-center version-cell version-big version-legacy">{{- crate::template_funcs::format_number_short(repository.num_packages_legacy) -}}</td>
 
-			<td class="text-center version-cell version-big version-rolling">{{ repository.num_packages_rolling }}</td>
-			<td class="text-center version-cell version-big version-noscheme">{{ repository.num_packages_noscheme }}</td>
-			<td class="text-center version-cell version-big version-incorrect">{{ repository.num_packages_incorrect }}</td>
-			<td class="text-center version-cell version-big version-untrusted">{{ repository.num_packages_untrusted }}</td>
-			<td class="text-center version-cell version-big version-ignored">{{ repository.num_packages_ignored }}</td>
+			<td class="text-center version-cell version-big version-rolling">{{- crate::template_funcs::format_number_short(repository.num_packages_rolling) -}}</td>
+			<td class="text-center version-cell version-big version-noscheme">{{- crate::template_funcs::format_number_short(repository.num_packages_noscheme) -}}</td>
+			<td class="text-center version-cell version-big version-incorrect">{{- crate::template_funcs::format_number_short(repository.num_packages_incorrect) -}}</td>
+			<td class="text-center version-cell version-big version-untrusted">{{- crate::template_funcs::format_number_short(repository.num_packages_untrusted) -}}</td>
+			<td class="text-center version-cell version-big version-ignored">{{- crate::template_funcs::format_number_short(repository.num_packages_ignored) -}}</td>
 
-			<td class="text-center vulnerable-cell">{{ repository.num_packages_vulnerable }}</td>
+			<td class="text-center vulnerable-cell">{{- crate::template_funcs::format_number_short(repository.num_packages_vulnerable) -}}</td>
 		</tr>
 	{% endfor %}
 	</tbody>

--- a/repology-webapp/templates/repositories/statistics.html
+++ b/repology-webapp/templates/repositories/statistics.html
@@ -47,8 +47,8 @@
 			<th class="text-center" rowspan="2">Problems</th>
 		</tr>
 		<tr>
-			<th class="text-center">Total</th>
-			<th class="text-center"><abbr title="Non-unique">N/u</abbr></th>
+			<th class="text-center" title="Total number of projects packaged in this repository">Total</th>
+			<th class="text-center" title="Number of non-unique projects packaged in this repository">N/u</th>
 			<th class="text-center" colspan="2">Newest</th>
 			<th class="text-center" colspan="2">Outdated</th>
 			<th class="text-center" colspan="2">Unique</th>
@@ -63,21 +63,22 @@
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Repository, [("repository_name", repository.name.as_str())])? }}">{{ repository.title }}</a>
 			</th>
 
-			<td class="text-center total-cell" title="Total number of projects packaged in this repository">
+			<td class="text-center total-cell">
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str())])? }}">
-					{{- repository.num_projects -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects) -}}
 				</a>
 			</td>
 
-			<td class="text-center total-cell" title="Number of non-unique projects packaged in this repository">
+			<td class="text-center total-cell">
+			    {% let non_unique = repository.num_projects - repository.num_projects_unique %}
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("families", "2-")])? }}">
-					{{- repository.num_projects - repository.num_projects_unique -}}
+					{{- crate::template_funcs::format_number_short(non_unique) -}}
 				</a>
 			</td>
 
 			<td class="text-center version-cell version-big version-newest">
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("newest", "1")])? }}">
-					{{- repository.num_projects_newest -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects_newest) -}}
 				</a>
 			</td>
 			<td class="text-center version-cell version-big version-newest">
@@ -86,7 +87,7 @@
 
 			<td class="text-center version-cell version-big version-outdated">
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("outdated", "1")])? }}">
-					{{- repository.num_projects_outdated -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects_outdated) -}}
 				</a>
 			</td>
 			<td class="text-center version-cell version-big version-outdated">
@@ -98,7 +99,7 @@
 				<span title="This is a shadow repo, e.g. unique packages in it are ignored">n/a</span>
 			{% else %}
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("families", "1")])? }}">
-					{{- repository.num_projects_unique -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects_unique) -}}
 				</a>
 			{% endif %}
 			</td>
@@ -112,7 +113,7 @@
 
 			<td class="text-center version-cell version-big version-ignored">
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("problematic", "1")])? }}">
-					{{- repository.num_projects_problematic -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects_problematic) -}}
 				</a>
 			</td>
 			<td class="text-center version-cell version-big version-ignored">
@@ -121,7 +122,7 @@
 
 			<td class="text-center{% if repository.num_projects_vulnerable > 0 %} vulnerable-cell{% endif %}">
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::Projects, [("inrepo", repository.name.as_str()), ("vulnerable", "1")])? }}">
-					{{- repository.num_projects_vulnerable -}}
+					{{- crate::template_funcs::format_number_short(repository.num_projects_vulnerable) -}}
 				</a>
 			</td>
 			<td class="text-center{% if repository.num_projects_vulnerable > 0 %} vulnerable-cell{% endif %}">
@@ -130,7 +131,7 @@
 
 			<td class="text-center">
 				{%- if repository.num_maintainers > 0 -%}
-				{{- repository.num_maintainers -}}
+				{{- crate::template_funcs::format_number_short(repository.num_maintainers) -}}
 			{%- else -%}
 				?
 			{%- endif -%}
@@ -139,7 +140,7 @@
 			<td class="text-center">
 			{%- if repository.num_problems > 0 -%}
 				<a href="{{ ctx.url_for(crate::endpoints::Endpoint::RepositoryProblems, [("repository_name", repository.name.as_str())])? }}">
-					{{- repository.num_problems -}}
+					{{- crate::template_funcs::format_number_short(repository.num_problems) -}}
 				</a>
 			{%- else -%}
 				0


### PR DESCRIPTION
- Add a helper in the template context to shorten numbers ≥1000 to a “k” format (e.g., 12345 → 12k) for /repositories endpoints
- Add tests